### PR TITLE
Optimize admin page query performance: use caching and JOINs instead …

### DIFF
--- a/admin/classes.php
+++ b/admin/classes.php
@@ -73,14 +73,14 @@ $stmt = $conn->prepare("
         {$subject_fields_select},
         CONCAT(i.first_name, ' ', i.last_name) AS instructor_name,
         cr.room_number,
-        (SELECT COUNT(*) FROM enrollments e
-            WHERE e.schedule_id = s.id AND e.status IN ('approved', 'enrolled')
-        ) AS enrolled_students
+        COUNT(DISTINCT e.id) AS enrolled_students
     FROM schedules s
     JOIN courses c ON c.id = s.course_id
     {$subject_join_sql}
     JOIN users i ON i.id = s.instructor_id
     JOIN classrooms cr ON cr.id = s.classroom_id
+    LEFT JOIN enrollments e ON e.schedule_id = s.id AND e.status IN ('approved', 'enrolled')
+    GROUP BY s.id
     ORDER BY (s.status = 'active') DESC, {$order_by_name}, s.day_of_week, s.start_time
 ");
 $stmt->execute();

--- a/admin/courses.php
+++ b/admin/courses.php
@@ -24,13 +24,15 @@ $qs_prev = http_build_query(array_merge($_GET, ['page' => max(1, $page - 1)]));
 $qs_next = http_build_query(array_merge($_GET, ['page' => min($total_pages, $page + 1)]));
 
 // Get paginated courses with their schedule and enrollment counts
+// PERFORMANCE: Use JOINs instead of subqueries for faster execution
 $stmt = $conn->prepare("
     SELECT c.*,
-           (SELECT COUNT(*) FROM schedules WHERE course_id = c.id AND status = 'active') as schedule_count,
-           (SELECT COUNT(*) FROM enrollments e
-            JOIN schedules s ON e.schedule_id = s.id
-            WHERE s.course_id = c.id AND e.status IN ('approved', 'enrolled')) as enrollment_count
+           COUNT(DISTINCT s.id) as schedule_count,
+           COUNT(DISTINCT e.id) as enrollment_count
     FROM courses c
+    LEFT JOIN schedules s ON c.id = s.course_id AND s.status = 'active'
+    LEFT JOIN enrollments e ON s.id = e.schedule_id AND e.status IN ('approved', 'enrolled')
+    GROUP BY c.id
     ORDER BY c.course_code
     LIMIT :limit OFFSET :offset
 ");

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -120,15 +120,31 @@ $recent_subject_name_expr = ($has_schedule_subject_id && $subjects_table_exists)
 
 // Get system statistics
 try {
-    $stats = [
-        'total_users' => (int)$conn->query("SELECT COUNT(*) FROM users")->fetchColumn(),
-        'students' => (int)$conn->query("SELECT COUNT(*) FROM users WHERE role = 'student'")->fetchColumn(),
-        'instructors' => (int)$conn->query("SELECT COUNT(*) FROM users WHERE role = 'instructor'")->fetchColumn(),
-        'active_classes' => admin_dashboard_count_grouped_active_classes($conn),
-        'total_enrollments' => (int)$conn->query("SELECT COUNT(*) FROM enrollments WHERE status IN ('enrolled', 'approved')")->fetchColumn(),
-        'enrolled_students' => (int)$conn->query("SELECT COUNT(DISTINCT student_id) FROM enrollments WHERE status IN ('enrolled', 'approved')")->fetchColumn(),
-        'courses' => (int)$conn->query("SELECT COUNT(*) FROM courses")->fetchColumn(),
-    ];
+    $cache_key = 'pct_dashboard_stats_cache';
+    $cache_dir = sys_get_temp_dir();
+    $cache_file = $cache_dir . DIRECTORY_SEPARATOR . $cache_key . '.json';
+    $cache_ttl = 300; // 5 minutes
+    
+    $stats = null;
+    if (file_exists($cache_file)) {
+        $cache_data = json_decode(file_get_contents($cache_file), true);
+        if ($cache_data && isset($cache_data['timestamp']) && (time() - $cache_data['timestamp']) < $cache_ttl) {
+            $stats = $cache_data['data'];
+        }
+    }
+    
+    if (!$stats) {
+        $stats = [
+            'total_users' => (int)$conn->query("SELECT COUNT(*) FROM users")->fetchColumn(),
+            'students' => (int)$conn->query("SELECT COUNT(*) FROM users WHERE role = 'student'")->fetchColumn(),
+            'instructors' => (int)$conn->query("SELECT COUNT(*) FROM users WHERE role = 'instructor'")->fetchColumn(),
+            'active_classes' => admin_dashboard_count_grouped_active_classes($conn),
+            'total_enrollments' => (int)$conn->query("SELECT COUNT(*) FROM enrollments WHERE status IN ('enrolled', 'approved')")->fetchColumn(),
+            'enrolled_students' => (int)$conn->query("SELECT COUNT(DISTINCT student_id) FROM enrollments WHERE status IN ('enrolled', 'approved')")->fetchColumn(),
+            'courses' => (int)$conn->query("SELECT COUNT(*) FROM courses")->fetchColumn(),
+        ];
+        file_put_contents($cache_file, json_encode(['timestamp' => time(), 'data' => $stats]));
+    }
 } catch (PDOException $e) {
     error_log('Error in admin dashboard: ' . $e->getMessage());
     $stats = ['total_users' => 0, 'students' => 0, 'instructors' => 0, 'active_classes' => 0, 'total_enrollments' => 0, 'enrolled_students' => 0, 'courses' => 0];

--- a/admin/instructors.php
+++ b/admin/instructors.php
@@ -14,6 +14,12 @@ require_once __DIR__ . '/notifications_data.php';
 $search = isset($_GET['search']) ? $_GET['search'] : '';
 $filter = isset($_GET['filter']) ? $_GET['filter'] : 'all';
 
+// PERFORMANCE: Added caching for instructor list (5-minute TTL)
+$cache_key = 'pct_instructors_cache';
+$cache_dir = sys_get_temp_dir();
+$cache_file = $cache_dir . DIRECTORY_SEPARATOR . $cache_key . '.json';
+$cache_ttl = 300; // 5 minutes
+
 // Main query (uses schedules; older versions referenced a non-existent `classes` table)
 $stmt = $conn->prepare("
     SELECT u.*, 
@@ -41,14 +47,37 @@ if (!empty($search)) {
 $stmt->execute();
 $instructors = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-// Get total counts for filters
-$total_instructors = $conn->query("SELECT COUNT(*) FROM users WHERE role = 'instructor'")->fetchColumn();
-$active_instructors = $conn->query("
-    SELECT COUNT(DISTINCT u.id) 
-    FROM users u 
-    JOIN schedules s ON u.id = s.instructor_id 
-    WHERE u.role = 'instructor' AND s.status = 'active'")->fetchColumn();
-$inactive_instructors = $total_instructors - $active_instructors;
+// Get total counts for filters - use cache for these statistics
+$counts_cache_file = $cache_dir . DIRECTORY_SEPARATOR . 'pct_instructor_counts_cache.json';
+$instructor_counts = null;
+
+if (file_exists($counts_cache_file)) {
+    $cache_data = json_decode(file_get_contents($counts_cache_file), true);
+    if ($cache_data && isset($cache_data['timestamp']) && (time() - $cache_data['timestamp']) < $cache_ttl) {
+        $instructor_counts = $cache_data['data'];
+    }
+}
+
+if ($instructor_counts === null) {
+    $total_instructors = $conn->query("SELECT COUNT(*) FROM users WHERE role = 'instructor'")->fetchColumn();
+    $active_instructors = $conn->query("
+        SELECT COUNT(DISTINCT u.id) 
+        FROM users u 
+        JOIN schedules s ON u.id = s.instructor_id 
+        WHERE u.role = 'instructor' AND s.status = 'active'")->fetchColumn();
+    $inactive_instructors = $total_instructors - $active_instructors;
+    
+    $instructor_counts = [
+        'total' => $total_instructors,
+        'active' => $active_instructors,
+        'inactive' => $inactive_instructors
+    ];
+    file_put_contents($counts_cache_file, json_encode(['timestamp' => time(), 'data' => $instructor_counts]));
+}
+
+$total_instructors = $instructor_counts['total'];
+$active_instructors = $instructor_counts['active'];
+$inactive_instructors = $instructor_counts['inactive'];
 
 function initials_for($first_name, $last_name, $fallback) {
     $fi = strtoupper(substr((string)$first_name, 0, 1));

--- a/admin/schedules.php
+++ b/admin/schedules.php
@@ -10,69 +10,90 @@ if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'super_admin')
 
 require_once __DIR__ . '/notifications_data.php';
 
-// Schedules schema compatibility (some DB versions don't store end_time)
-$schedule_cols_stmt = $conn->prepare('DESCRIBE schedules');
-$schedule_cols_stmt->execute();
-$schedule_cols = [];
-foreach ($schedule_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
-    $schedule_cols[$r['Field']] = true;
+// PERFORMANCE: Cache schedules for 5 minutes to avoid repeated expensive queries
+$cache_dir = sys_get_temp_dir();
+$cache_file = $cache_dir . '/pct_schedules_cache.json';
+$cache_ttl = 300; // 5 minutes
+$use_cache = true;
+
+// Try to load from cache if fresh
+$schedules = [];
+if (file_exists($cache_file) && (time() - filemtime($cache_file)) < $cache_ttl) {
+    $cached_data = @json_decode(file_get_contents($cache_file), true);
+    if ($cached_data !== null) {
+        $schedules = $cached_data;
+        $use_cache = false; // Mark that we used cache
+    }
 }
 
-if (isset($schedule_cols['end_time'])) {
-    $end_expr = 's.end_time';
-} elseif (isset($schedule_cols['duration_minutes'])) {
-    $end_expr = 'ADDTIME(s.start_time, SEC_TO_TIME(s.duration_minutes * 60))';
-} else {
-    $end_expr = 'ADDTIME(s.start_time, SEC_TO_TIME(120 * 60))';
-}
+// If cache miss or stale, fetch from database
+if ($use_cache) {
+    // Schedules schema compatibility
+    $schedule_cols_stmt = $conn->prepare('DESCRIBE schedules');
+    $schedule_cols_stmt->execute();
+    $schedule_cols = [];
+    foreach ($schedule_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+        $schedule_cols[$r['Field']] = true;
+    }
 
-$start_date_expr = isset($schedule_cols['start_date'])
-    ? "DATE_FORMAT(COALESCE(s.start_date, DATE(s.created_at)), '%Y-%m-%d')"
-    : "DATE_FORMAT(DATE(s.created_at), '%Y-%m-%d')";
-$end_date_expr = isset($schedule_cols['end_date'])
-    ? "DATE_FORMAT(COALESCE(s.end_date, DATE_ADD(COALESCE(s.start_date, DATE(s.created_at)), INTERVAL 17 DAY)), '%Y-%m-%d')"
-    : "DATE_FORMAT(DATE_ADD(DATE(s.created_at), INTERVAL 17 DAY), '%Y-%m-%d')";
+    if (isset($schedule_cols['end_time'])) {
+        $end_expr = 's.end_time';
+    } elseif (isset($schedule_cols['duration_minutes'])) {
+        $end_expr = 'ADDTIME(s.start_time, SEC_TO_TIME(s.duration_minutes * 60))';
+    } else {
+        $end_expr = 'ADDTIME(s.start_time, SEC_TO_TIME(120 * 60))';
+    }
 
-// Detect if subjects table exists (avoid fatal errors on older DBs)
-$subjects_table_exists = false;
-try {
-    $stmt = $conn->prepare("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'subjects'");
-    $stmt->execute();
-    $subjects_table_exists = ((int)$stmt->fetchColumn() > 0);
-} catch (Throwable $e) {
+    $start_date_expr = isset($schedule_cols['start_date'])
+        ? "DATE_FORMAT(COALESCE(s.start_date, DATE(s.created_at)), '%Y-%m-%d')"
+        : "DATE_FORMAT(DATE(s.created_at), '%Y-%m-%d')";
+    $end_date_expr = isset($schedule_cols['end_date'])
+        ? "DATE_FORMAT(COALESCE(s.end_date, DATE_ADD(COALESCE(s.start_date, DATE(s.created_at)), INTERVAL 17 DAY)), '%Y-%m-%d')"
+        : "DATE_FORMAT(DATE_ADD(DATE(s.created_at), INTERVAL 17 DAY), '%Y-%m-%d')";
+
+    // Detect if subjects table exists
     $subjects_table_exists = false;
+    try {
+        $stmt = $conn->prepare("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'subjects'");
+        $stmt->execute();
+        $subjects_table_exists = ((int)$stmt->fetchColumn() > 0);
+    } catch (Throwable $e) {
+        $subjects_table_exists = false;
+    }
+
+    $subject_code_expr = $subjects_table_exists
+        ? "COALESCE(NULLIF(TRIM(sub.subject_code), ''), NULLIF(TRIM(c.course_code), ''))"
+        : "NULLIF(TRIM(c.course_code), '')";
+    $subject_name_expr = $subjects_table_exists
+        ? "COALESCE(NULLIF(TRIM(sub.subject_name), ''), NULLIF(TRIM(c.course_name), ''))"
+        : "NULLIF(TRIM(c.course_name), '')";
+    $subjects_join = $subjects_table_exists ? 'LEFT JOIN subjects sub ON (s.subject_id IS NOT NULL AND s.subject_id = sub.id)' : '';
+
+    $stmt = $conn->prepare("
+        SELECT s.*, 
+               {$subject_code_expr} as subject_code,
+               {$subject_name_expr} as subject_name,
+               CONCAT(i.first_name, ' ', i.last_name) as instructor_name,
+               r.room_number,
+               COUNT(DISTINCT e.id) as enrollment_count,
+                TIME_FORMAT({$end_expr}, '%H:%i:%s') as end_time,
+                {$start_date_expr} as start_date,
+                {$end_date_expr} as end_date
+        FROM schedules s
+        {$subjects_join}
+        LEFT JOIN courses c ON (s.course_id IS NOT NULL AND s.course_id = c.id)
+        JOIN users i ON s.instructor_id = i.id
+        JOIN classrooms r ON s.classroom_id = r.id
+        LEFT JOIN enrollments e ON s.id = e.schedule_id AND e.status = 'enrolled'
+        GROUP BY s.id
+        ORDER BY s.day_of_week, s.start_time
+    ");
+    $stmt->execute();
+    $schedules = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    
+    // Cache the results for next page load
+    @file_put_contents($cache_file, json_encode($schedules));
 }
-
-// Get all schedules with their subject (preferred) / course (legacy) and instructor information
-$subject_code_expr = $subjects_table_exists
-    ? "COALESCE(NULLIF(TRIM(sub.subject_code), ''), NULLIF(TRIM(c.course_code), ''))"
-    : "NULLIF(TRIM(c.course_code), '')";
-$subject_name_expr = $subjects_table_exists
-    ? "COALESCE(NULLIF(TRIM(sub.subject_name), ''), NULLIF(TRIM(c.course_name), ''))"
-    : "NULLIF(TRIM(c.course_name), '')";
-$subjects_join = $subjects_table_exists ? 'LEFT JOIN subjects sub ON (s.subject_id IS NOT NULL AND s.subject_id = sub.id)' : '';
-
-$stmt = $conn->prepare("
-    SELECT s.*, 
-           {$subject_code_expr} as subject_code,
-           {$subject_name_expr} as subject_name,
-           CONCAT(i.first_name, ' ', i.last_name) as instructor_name,
-           r.room_number,
-           COUNT(DISTINCT e.id) as enrollment_count,
-            TIME_FORMAT({$end_expr}, '%H:%i:%s') as end_time,
-            {$start_date_expr} as start_date,
-            {$end_date_expr} as end_date
-    FROM schedules s
-    {$subjects_join}
-    LEFT JOIN courses c ON (s.course_id IS NOT NULL AND s.course_id = c.id)
-    JOIN users i ON s.instructor_id = i.id
-    JOIN classrooms r ON s.classroom_id = r.id
-    LEFT JOIN enrollments e ON s.id = e.schedule_id AND e.status = 'enrolled'
-    GROUP BY s.id
-    ORDER BY s.day_of_week, s.start_time
-");
-$stmt->execute();
-$schedules = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Final guard: collapse exact duplicate cards that may still exist in legacy data.
 $card_dedup_map = [];

--- a/admin/students.php
+++ b/admin/students.php
@@ -12,41 +12,71 @@ require_once __DIR__ . '/notifications_data.php';
 
 $default_department = 'Information of Technology Education';
 
-// Get all students with enrollment counts + enrolled course codes
-$stmt = $conn->prepare("
-    SELECT u.*,
-           COUNT(DISTINCT e.id) as enrollment_count,
-           GROUP_CONCAT(DISTINCT c.course_code ORDER BY c.course_code SEPARATOR ', ') as enrolled_courses
-    FROM users u
-    LEFT JOIN enrollments e ON u.id = e.student_id AND e.status IN ('enrolled', 'approved')
-    LEFT JOIN schedules sch ON e.schedule_id = sch.id
-    LEFT JOIN courses c ON sch.course_id = c.id
-    WHERE u.role = 'student'
-    GROUP BY u.id
-    ORDER BY u.last_name, u.first_name
-");
-$stmt->execute();
-$students = $stmt->fetchAll(PDO::FETCH_ASSOC);
+// PERFORMANCE: Added caching for student list (5-minute TTL)
+$cache_key = 'pct_students_cache';
+$cache_dir = sys_get_temp_dir();
+$cache_file = $cache_dir . DIRECTORY_SEPARATOR . $cache_key . '.json';
+$cache_ttl = 300; // 5 minutes
 
-// Summary cards (top 4 courses by enrolled students)
-$course_summary = [];
-try {
-    $stmt = $conn->query("
-        SELECT
-            c.course_code,
-            COUNT(DISTINCT e.student_id) as students
-        FROM enrollments e
-        JOIN schedules sch ON e.schedule_id = sch.id
-        JOIN courses c ON sch.course_id = c.id
-        WHERE e.status IN ('enrolled', 'approved')
-        GROUP BY c.id
-        ORDER BY students DESC
-        LIMIT 4
+$students = null;
+if (file_exists($cache_file)) {
+    $cache_data = json_decode(file_get_contents($cache_file), true);
+    if ($cache_data && isset($cache_data['timestamp']) && (time() - $cache_data['timestamp']) < $cache_ttl) {
+        $students = $cache_data['data'];
+    }
+}
+
+if ($students === null) {
+    // Get all students with enrollment counts + enrolled course codes
+    $stmt = $conn->prepare("
+        SELECT u.*,
+               COUNT(DISTINCT e.id) as enrollment_count,
+               GROUP_CONCAT(DISTINCT c.course_code ORDER BY c.course_code SEPARATOR ', ') as enrolled_courses
+        FROM users u
+        LEFT JOIN enrollments e ON u.id = e.student_id AND e.status IN ('enrolled', 'approved')
+        LEFT JOIN schedules sch ON e.schedule_id = sch.id
+        LEFT JOIN courses c ON sch.course_id = c.id
+        WHERE u.role = 'student'
+        GROUP BY u.id
+        ORDER BY u.last_name, u.first_name
     ");
-    $course_summary = $stmt->fetchAll(PDO::FETCH_ASSOC);
-} catch (PDOException $e) {
-    error_log('Error fetching students course summary: ' . $e->getMessage());
-    $course_summary = [];
+    $stmt->execute();
+    $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    file_put_contents($cache_file, json_encode(['timestamp' => time(), 'data' => $students]));
+}
+
+// Summary cards (top 4 courses by enrolled students) - with caching
+$course_summary_cache_key = 'pct_students_course_summary_cache';
+$course_summary_cache_file = $cache_dir . DIRECTORY_SEPARATOR . $course_summary_cache_key . '.json';
+
+$course_summary = [];
+if (file_exists($course_summary_cache_file)) {
+    $cache_data = json_decode(file_get_contents($course_summary_cache_file), true);
+    if ($cache_data && isset($cache_data['timestamp']) && (time() - $cache_data['timestamp']) < $cache_ttl) {
+        $course_summary = $cache_data['data'];
+    }
+}
+
+if (empty($course_summary)) {
+    try {
+        $stmt = $conn->query("
+            SELECT
+                c.course_code,
+                COUNT(DISTINCT e.student_id) as students
+            FROM enrollments e
+            JOIN schedules sch ON e.schedule_id = sch.id
+            JOIN courses c ON sch.course_id = c.id
+            WHERE e.status IN ('enrolled', 'approved')
+            GROUP BY c.id
+            ORDER BY students DESC
+            LIMIT 4
+        ");
+        $course_summary = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        file_put_contents($course_summary_cache_file, json_encode(['timestamp' => time(), 'data' => $course_summary]));
+    } catch (PDOException $e) {
+        error_log('Error fetching students course summary: ' . $e->getMessage());
+        $course_summary = [];
+    }
 }
 
 // CSV export


### PR DESCRIPTION
…of subqueries

- Added 5-minute TTL file-based caching for dashboard stats, students, and instructors list
- Replaced subquery-based enrollment counts with efficient LEFT JOINs and GROUP BY
- Optimized courses.php query to use JOINs instead of nested subqueries
- Improved classes.php by replacing enrollment count subquery with JOIN
- Reduced database load significantly for free tier Render deployment
- All cached data uses /tmp/pct_*_cache.json for automatic cleanup