### PR TITLE
Add PostgreSQL compatibility layer and fix database queries

### DIFF
--- a/admin/classes.php
+++ b/admin/classes.php
@@ -13,16 +13,14 @@ require_once __DIR__ . '/notifications_data.php';
 $initial_search = trim((string)($_GET['search'] ?? ''));
 
 // Subjects table may not exist on older DBs
-$subjects_table_exists_stmt = $conn->prepare("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'subjects'");
-$subjects_table_exists_stmt->execute();
-$subjects_table_exists = ((int)$subjects_table_exists_stmt->fetchColumn() > 0);
+$subjects_table_exists = table_exists($conn, 'subjects');
 
 // Schedules schema compatibility (some DB versions don't store end_time)
-$schedule_cols_stmt = $conn->prepare('DESCRIBE schedules');
-$schedule_cols_stmt->execute();
+$schedule_cols_result = get_table_columns($conn, 'schedules');
 $schedule_cols = [];
-foreach ($schedule_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
-    $schedule_cols[$r['Field']] = true;
+foreach ($schedule_cols_result as $r) {
+    $col_name = isset($r['Field']) ? $r['Field'] : $r['column_name'];
+    $schedule_cols[$col_name] = true;
 }
 
 if (isset($schedule_cols['end_time'])) {

--- a/admin/classrooms.php
+++ b/admin/classrooms.php
@@ -11,11 +11,11 @@ if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'super_admin') {
 require_once __DIR__ . '/notifications_data.php';
 
 // Schedules schema compatibility (some DB versions don't store end_time)
-$schedule_cols_stmt = $conn->prepare('DESCRIBE schedules');
-$schedule_cols_stmt->execute();
+$schedule_cols_result = get_table_columns($conn, 'schedules');
 $schedule_cols = [];
-foreach ($schedule_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
-    $schedule_cols[$r['Field']] = true;
+foreach ($schedule_cols_result as $r) {
+    $col_name = isset($r['Field']) ? $r['Field'] : $r['column_name'];
+    $schedule_cols[$col_name] = true;
 }
 
 if (isset($schedule_cols['end_time'])) {

--- a/admin/enrollments.php
+++ b/admin/enrollments.php
@@ -11,19 +11,19 @@ if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'super_admin')
 require_once __DIR__ . '/notifications_data.php';
 
 // Schedules schema compatibility (some DB versions don't store end_time)
-$schedule_cols_stmt = $conn->prepare('DESCRIBE schedules');
-$schedule_cols_stmt->execute();
+$schedule_cols_result = get_table_columns($conn, 'schedules');
 $schedule_cols = [];
-foreach ($schedule_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
-    $schedule_cols[$r['Field']] = true;
+foreach ($schedule_cols_result as $r) {
+    $col_name = isset($r['Field']) ? $r['Field'] : $r['column_name'];
+    $schedule_cols[$col_name] = true;
 }
 
 // Enrollments schema compatibility (date columns may vary)
-$enroll_cols_stmt = $conn->prepare('DESCRIBE enrollments');
-$enroll_cols_stmt->execute();
+$enroll_cols_result = get_table_columns($conn, 'enrollments');
 $enroll_cols = [];
-foreach ($enroll_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
-    $enroll_cols[$r['Field']] = true;
+foreach ($enroll_cols_result as $r) {
+    $col_name = isset($r['Field']) ? $r['Field'] : $r['column_name'];
+    $enroll_cols[$col_name] = true;
 }
 
 function schedule_end_expr(array $schedule_cols, string $alias = ''): string {

--- a/admin/instructors.php
+++ b/admin/instructors.php
@@ -15,11 +15,11 @@ $search = isset($_GET['search']) ? $_GET['search'] : '';
 $filter = isset($_GET['filter']) ? $_GET['filter'] : 'all';
 
 // Main query (uses schedules; older versions referenced a non-existent `classes` table)
-$stmt = $conn->prepare("
+$sql = "
     SELECT u.*, 
            COUNT(DISTINCT s.id) as class_count,
            COUNT(DISTINCT e.student_id) as student_count,
-           GROUP_CONCAT(DISTINCT c.course_code ORDER BY c.course_code SEPARATOR ', ') as courses
+           " . (is_pgsql() ? "string_agg(DISTINCT c.course_code, ', ' ORDER BY c.course_code)" : "GROUP_CONCAT(DISTINCT c.course_code ORDER BY c.course_code SEPARATOR ', ')") . " as courses
     FROM users u
     LEFT JOIN schedules s ON u.id = s.instructor_id AND s.status = 'active'
     LEFT JOIN courses c ON s.course_id = c.id
@@ -33,7 +33,8 @@ $stmt = $conn->prepare("
         ) : "") . "
     GROUP BY u.id
     ORDER BY u.last_name, u.first_name
-");
+";
+$stmt = $conn->prepare($sql);
 
 if (!empty($search)) {
     $stmt->bindValue(':search', "%$search%", PDO::PARAM_STR);

--- a/admin/schedules.php
+++ b/admin/schedules.php
@@ -11,11 +11,11 @@ if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'super_admin')
 require_once __DIR__ . '/notifications_data.php';
 
 // Schedules schema compatibility (some DB versions don't store end_time)
-$schedule_cols_stmt = $conn->prepare('DESCRIBE schedules');
-$schedule_cols_stmt->execute();
+$schedule_cols_result = get_table_columns($conn, 'schedules');
 $schedule_cols = [];
-foreach ($schedule_cols_stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
-    $schedule_cols[$r['Field']] = true;
+foreach ($schedule_cols_result as $r) {
+    $col_name = isset($r['Field']) ? $r['Field'] : $r['column_name'];
+    $schedule_cols[$col_name] = true;
 }
 
 if (isset($schedule_cols['end_time'])) {

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -10,15 +10,7 @@ if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'super_admin')
 
 require_once __DIR__ . '/notifications_data.php';
 
-function table_exists(PDO $conn, string $table): bool {
-    // MariaDB/MySQL does not reliably support placeholders in SHOW TABLES.
-    // Use information_schema instead (safe parameterization).
-    $stmt = $conn->prepare(
-        'SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1'
-    );
-    $stmt->execute([$table]);
-    return (bool)$stmt->fetchColumn();
-}
+// Use the global table_exists() from database-compatibility.php, no need to redefine
 
 $settings_array = [
     'school_name' => 'Philippine College of Technology',

--- a/admin/students.php
+++ b/admin/students.php
@@ -13,10 +13,10 @@ require_once __DIR__ . '/notifications_data.php';
 $default_department = 'Information of Technology Education';
 
 // Get all students with enrollment counts + enrolled course codes
-$stmt = $conn->prepare("
+$sql = "
     SELECT u.*,
            COUNT(DISTINCT e.id) as enrollment_count,
-           GROUP_CONCAT(DISTINCT c.course_code ORDER BY c.course_code SEPARATOR ', ') as enrolled_courses
+           " . (is_pgsql() ? "string_agg(DISTINCT c.course_code, ', ' ORDER BY c.course_code)" : "GROUP_CONCAT(DISTINCT c.course_code ORDER BY c.course_code SEPARATOR ', ')") . " as enrolled_courses
     FROM users u
     LEFT JOIN enrollments e ON u.id = e.student_id AND e.status IN ('enrolled', 'approved')
     LEFT JOIN schedules sch ON e.schedule_id = sch.id
@@ -24,7 +24,8 @@ $stmt = $conn->prepare("
     WHERE u.role = 'student'
     GROUP BY u.id
     ORDER BY u.last_name, u.first_name
-");
+";
+$stmt = $conn->prepare($sql);
 $stmt->execute();
 $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
 

--- a/config/database-compatibility.php
+++ b/config/database-compatibility.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * SQL Compatibility Helper Functions
+ * Bridges differences between MySQL and PostgreSQL
+ */
+
+/**
+ * Replace MySQL-specific SQL with PostgreSQL-compatible SQL
+ */
+function convert_sql_for_postgresql($sql) {
+    // Don't modify if already converted or if it's simple
+    if (empty($sql)) {
+        return $sql;
+    }
+
+    // Replace GROUP_CONCAT with string_agg for PostgreSQL
+    // Pattern: GROUP_CONCAT(col ORDER BY ... SEPARATOR ',')
+    $sql = preg_replace_callback(
+        '/GROUP_CONCAT\s*\(\s*([^,]+)\s+ORDER\s+BY\s+([^S]+)\s+SEPARATOR\s+[\'"]([^\'"]+)[\'"]\s*\)/i',
+        function($matches) {
+            return "string_agg($matches[1]::text, '$matches[3]' ORDER BY $matches[2])";
+        },
+        $sql
+    );
+
+    // Replace simple GROUP_CONCAT without ORDER BY
+    // Pattern: GROUP_CONCAT(col SEPARATOR ',')
+    $sql = preg_replace_callback(
+        '/GROUP_CONCAT\s*\(\s*([^S]+)\s+SEPARATOR\s+[\'"]([^\'"]+)[\'"]\s*\)/i',
+        function($matches) {
+            return "string_agg($matches[1]::text, '$matches[2]')";
+        },
+        $sql
+    );
+
+    // Replace DATABASE() with current_database()
+    $sql = preg_replace('/DATABASE\(\)/i', "current_database()", $sql);
+
+    return $sql;
+}
+
+/**
+ * Execute a query with PostgreSQL/MySQL compatibility
+ * Automatically converts MySQL-specific syntax
+ */
+function execute_compatible_query($conn, $sql, $params = []) {
+    global $_db_engine;
+    
+    if ($_db_engine === 'pgsql') {
+        $sql = convert_sql_for_postgresql($sql);
+    }
+    
+    try {
+        $stmt = $conn->prepare($sql);
+        $stmt->execute($params);
+        return $stmt;
+    } catch (PDOException $e) {
+        error_log("Query Error: " . $e->getMessage() . "\nSQL: $sql");
+        throw $e;
+    }
+}
+
+/**
+ * Get table structure info
+ * Replaces DESCRIBE for PostgreSQL
+ */
+function get_table_columns($conn, $table_name) {
+    global $_db_engine;
+    
+    try {
+        if ($_db_engine === 'pgsql') {
+            $sql = "SELECT column_name, data_type, is_nullable, column_default 
+                    FROM information_schema.columns 
+                    WHERE table_name = ? AND table_schema = 'public'
+                    ORDER BY ordinal_position";
+            $stmt = $conn->prepare($sql);
+            $stmt->execute([$table_name]);
+        } else {
+            // MySQL
+            $sql = "DESCRIBE $table_name";
+            $stmt = $conn->query($sql);
+        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    } catch (PDOException $e) {
+        error_log("Error getting table columns: " . $e->getMessage());
+        return [];
+    }
+}
+
+/**
+ * Check if table exists
+ * Replaces information_schema.tables queries for compatibility
+ */
+function table_exists($conn, $table_name) {
+    global $_db_engine;
+    
+    try {
+        if ($_db_engine === 'pgsql') {
+            $sql = "SELECT 1 FROM information_schema.tables 
+                    WHERE table_schema = 'public' 
+                    AND table_name = ?
+                    LIMIT 1";
+            $stmt = $conn->prepare($sql);
+            $stmt->execute([$table_name]);
+        } else {
+            // MySQL
+            $sql = "SELECT 1 FROM information_schema.tables 
+                    WHERE table_schema = DATABASE() 
+                    AND table_name = ?
+                    LIMIT 1";
+            $stmt = $conn->prepare($sql);
+            $stmt->execute([$table_name]);
+        }
+        return $stmt->rowCount() > 0;
+    } catch (PDOException $e) {
+        error_log("Error checking if table exists: " . $e->getMessage());
+        return false;
+    }
+}
+
+/**
+ * Get list of all tables in current database
+ */
+function get_all_tables($conn) {
+    global $_db_engine;
+    
+    try {
+        if ($_db_engine === 'pgsql') {
+            $sql = "SELECT table_name FROM information_schema.tables 
+                    WHERE table_schema = 'public'
+                    ORDER BY table_name";
+            $stmt = $conn->query($sql);
+        } else {
+            // MySQL
+            $sql = "SELECT table_name FROM information_schema.tables 
+                    WHERE table_schema = DATABASE()
+                    ORDER BY table_name";
+            $stmt = $conn->query($sql);
+        }
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return array_column($results, 'table_name');
+    } catch (PDOException $e) {
+        error_log("Error getting tables: " . $e->getMessage());
+        return [];
+    }
+}
+?>

--- a/config/database.php
+++ b/config/database.php
@@ -4,6 +4,29 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 require_once __DIR__ . '/app.php';
+require_once __DIR__ . '/database-compatibility.php';
+
+// Database Compatibility Helpers
+// These functions help bridge MySQL and PostgreSQL differences
+global $_db_engine;
+$_db_engine = getenv('DB_ENGINE') ?: 'mysql';
+
+// Helper function to check database type
+function is_pgsql() {
+    global $_db_engine;
+    return $_db_engine === 'pgsql';
+}
+
+// Helper function to get current database name for PostgreSQL
+function get_current_database_pgsql($conn) {
+    try {
+        $stmt = $conn->query("SELECT current_database()");
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $result['current_database'] ?? null;
+    } catch (Exception $e) {
+        return null;
+    }
+}
 
 /**
  * Inject global responsive assets into HTML responses.


### PR DESCRIPTION
- Create database-compatibility.php with helper functions for MySQL/PostgreSQL differences
- Replace DESCRIBE with get_table_columns() function
- Replace DATABASE() with table_exists() and get_current_database_pgsql()
- Replace GROUP_CONCAT with string_agg() for PostgreSQL
- Update admin pages to use compatibility functions