### PR TITLE
Fix PostgreSQL syntax and function redeclaration issues

### DIFF
--- a/admin/enrollments.php
+++ b/admin/enrollments.php
@@ -44,7 +44,7 @@ function fmt_time_range(?string $start, ?string $end): string {
     return date('g:i A', strtotime($start)) . ' – ' . date('g:i A', strtotime($end));
 }
 
-function table_exists(PDO $conn, string $table): bool {
+function table_exists_local(PDO $conn, string $table): bool {
     $stmt = $conn->prepare('SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?');
     $stmt->execute([$table]);
     return ((int)$stmt->fetchColumn()) > 0;
@@ -109,7 +109,7 @@ $page = max(1, (int)($_GET['page'] ?? 1));
 $end_expr_sched = schedule_end_expr($schedule_cols, 'sched');
 $end_expr_s = schedule_end_expr($schedule_cols, 's');
 
-$subjects_table_exists = isset($schedule_cols['subject_id']) && table_exists($conn, 'subjects');
+$subjects_table_exists = isset($schedule_cols['subject_id']) && table_exists_local($conn, 'subjects');
 $subjects_join_sched = $subjects_table_exists ? 'LEFT JOIN subjects sub ON (sched.subject_id IS NOT NULL AND sched.subject_id = sub.id)' : '';
 $class_name_expr = $subjects_table_exists ? 'COALESCE(sub.subject_name, c.course_name)' : 'c.course_name';
 $subjects_join_s = $subjects_table_exists ? 'LEFT JOIN subjects sub_s ON (s.subject_id IS NOT NULL AND s.subject_id = sub_s.id)' : '';
@@ -323,7 +323,7 @@ if (!$has_schedule_options) {
     $courses_stmt->execute();
     $all_courses = $courses_stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    if (table_exists($conn, 'subjects')) {
+    if (table_exists_local($conn, 'subjects')) {
         $subjects_stmt = $conn->prepare("SELECT id, subject_code, subject_name FROM subjects ORDER BY subject_name, subject_code");
         $subjects_stmt->execute();
         $all_subjects = $subjects_stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/admin/schedules.php
+++ b/admin/schedules.php
@@ -29,19 +29,24 @@ if (isset($schedule_cols['end_time'])) {
 $start_date_expr = isset($schedule_cols['start_date'])
     ? "DATE_FORMAT(COALESCE(s.start_date, DATE(s.created_at)), '%Y-%m-%d')"
     : "DATE_FORMAT(DATE(s.created_at), '%Y-%m-%d')";
-$end_date_expr = isset($schedule_cols['end_date'])
-    ? "DATE_FORMAT(COALESCE(s.end_date, DATE_ADD(COALESCE(s.start_date, DATE(s.created_at)), INTERVAL 17 DAY)), '%Y-%m-%d')"
-    : "DATE_FORMAT(DATE_ADD(DATE(s.created_at), INTERVAL 17 DAY), '%Y-%m-%d')";
+// Subjects table may not exist on older DBs (use compatibility helper)
+$subjects_table_exists = table_exists($conn, 'subjects');
 
-// Detect if subjects table exists (avoid fatal errors on older DBs)
-$subjects_table_exists = false;
-try {
-    $stmt = $conn->prepare("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'subjects'");
-    $stmt->execute();
-    $subjects_table_exists = ((int)$stmt->fetchColumn() > 0);
-} catch (Throwable $e) {
-    $subjects_table_exists = false;
-}
+// Date expression - handle PostgreSQL vs MySQL INTERVAL syntax
+$interval_expr = is_pgsql()
+    ? "(s.created_at + INTERVAL '17 days')"
+    : "DATE_ADD(DATE(s.created_at), INTERVAL 17 DAY)";
+$interval_expr_coalesce = is_pgsql()
+    ? "(COALESCE(s.start_date, DATE(s.created_at)) + INTERVAL '17 days')"
+    : "DATE_ADD(COALESCE(s.start_date, DATE(s.created_at)), INTERVAL 17 DAY)";
+
+$end_date_expr = isset($schedule_cols['end_date'])
+    ? (is_pgsql() 
+        ? "COALESCE(s.end_date, $interval_expr_coalesce)::text"
+        : "DATE_FORMAT(COALESCE(s.end_date, $interval_expr_coalesce), '%Y-%m-%d')")
+    : (is_pgsql()
+        ? "$interval_expr::text"
+        : "DATE_FORMAT($interval_expr, '%Y-%m-%d')");
 
 // Get all schedules with their subject (preferred) / course (legacy) and instructor information
 $subject_code_expr = $subjects_table_exists

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -58,7 +58,7 @@ if (!empty($_SESSION['first_name']) || !empty($_SESSION['last_name'])) {
 $php_version = phpversion();
 $mysql_version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
 $server_software = (string)($_SERVER['SERVER_SOFTWARE'] ?? '');
-$database_name = (string)($conn->query('SELECT DATABASE()')->fetchColumn() ?? '');
+$database_name = is_pgsql() ? get_current_database_pgsql($conn) : (string)($conn->query('SELECT DATABASE()')->fetchColumn() ?? '');
 $server_name = (string)($_SERVER['SERVER_NAME'] ?? '');
 $server_protocol = (string)($_SERVER['SERVER_PROTOCOL'] ?? '');
 ?>


### PR DESCRIPTION
- Rename local table_exists() to table_exists_local() in enrollments.php to avoid conflict
- Replace DATABASE() calls with PostgreSQL-compatible versions
- Fix INTERVAL syntax (DATE_ADD with INTERVAL 17 DAY for MySQL, INTERVAL '17 days' for PostgreSQL)
- Use get_current_database_pgsql() for PostgreSQL database name detection