### PR TITLE
Fix MySQL-specific SQL functions (SHOW COLUMNS, TIME_FORMAT, CONCAT)

### DIFF
--- a/admin/enrollments.php
+++ b/admin/enrollments.php
@@ -52,12 +52,34 @@ function table_exists_local(PDO $conn, string $table): bool {
 
 function enrollment_status_map(PDO $conn): array {
     // Some schemas use 'approved' instead of 'enrolled'.
-    $stmt = $conn->prepare("SHOW COLUMNS FROM enrollments LIKE 'status'");
-    $stmt->execute();
-    $row = $stmt->fetch(PDO::FETCH_ASSOC);
-    $type = (string)($row['Type'] ?? '');
+    // Get enum/column type in a database-agnostic way
+    $type = '';
+    try {
+        if (is_pgsql()) {
+            // PostgreSQL: get the data type
+            $stmt = $conn->prepare("
+                SELECT data_type 
+                FROM information_schema.columns 
+                WHERE table_name = 'enrollments' 
+                AND column_name = 'status'
+                AND table_schema = 'public'
+            ");
+            $stmt->execute();
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            $type = $row['data_type'] ?? '';
+        } else {
+            // MySQL: use SHOW COLUMNS
+            $stmt = $conn->prepare("SHOW COLUMNS FROM enrollments LIKE 'status'");
+            $stmt->execute();
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            $type = (string)($row['Type'] ?? '');
+        }
+    } catch (Exception $e) {
+        // Ignore query errors, use defaults below
+    }
 
     $allowed = [];
+    // Parse ENUM type from MySQL
     if (preg_match("/^enum\((.*)\)$/i", $type, $m)) {
         $vals = str_getcsv($m[1], ',', "'");
         foreach ($vals as $v) {

--- a/admin/schedules.php
+++ b/admin/schedules.php
@@ -57,14 +57,18 @@ $subject_name_expr = $subjects_table_exists
     : "NULLIF(TRIM(c.course_name), '')";
 $subjects_join = $subjects_table_exists ? 'LEFT JOIN subjects sub ON (s.subject_id IS NOT NULL AND s.subject_id = sub.id)' : '';
 
+$time_format_expr = is_pgsql() 
+    ? "TO_CHAR({$end_expr}, 'HH24:MI:SS')" 
+    : "TIME_FORMAT({$end_expr}, '%H:%i:%s')";
+
 $stmt = $conn->prepare("
     SELECT s.*, 
            {$subject_code_expr} as subject_code,
            {$subject_name_expr} as subject_name,
-           CONCAT(i.first_name, ' ', i.last_name) as instructor_name,
+           " . (is_pgsql() ? "(i.first_name || ' ' || i.last_name)" : "CONCAT(i.first_name, ' ', i.last_name)") . " as instructor_name,
            r.room_number,
            COUNT(DISTINCT e.id) as enrollment_count,
-            TIME_FORMAT({$end_expr}, '%H:%i:%s') as end_time,
+            {$time_format_expr} as end_time,
             {$start_date_expr} as start_date,
             {$end_date_expr} as end_date
     FROM schedules s


### PR DESCRIPTION
- Replace SHOW COLUMNS FROM with information_schema query for PostgreSQL compatibility
- Replace TIME_FORMAT() with TO_CHAR() for PostgreSQL
- Replace CONCAT() with || string concatenation for PostgreSQL
- Add database type checks (is_pgsql()) for conditional SQL generation